### PR TITLE
zephyr: only create named library if rpmi is selected via kconfig

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,6 +1,8 @@
+if (CONFIG_RISCV_RPMI)
+
 zephyr_library_named(rpmi)
 
-zephyr_library_sources_ifdef(CONFIG_RISCV_RPMI
+zephyr_library_sources(
   ${ZEPHYR_LIBRPMI_MODULE_DIR}/lib/rpmi_context.c
   ${ZEPHYR_LIBRPMI_MODULE_DIR}/lib/rpmi_hsm.c
   ${ZEPHYR_LIBRPMI_MODULE_DIR}/lib/rpmi_service_group_clock.c
@@ -13,7 +15,6 @@ zephyr_library_sources_ifdef(CONFIG_RISCV_RPMI
   ${ZEPHYR_LIBRPMI_MODULE_DIR}/lib/rpmi_transport.c
 )
 
-if (CONFIG_RISCV_RPMI)
   zephyr_include_directories(
     # ordering is important here, since we override the librpmi_env.h header
     ${CMAKE_CURRENT_SOURCE_DIR}/include


### PR DESCRIPTION
Previously, builds would receive the following warning when CONFIG_RISCV_RPMI was not set.

```
CMake Warning at .../zephyr/CMakeLists.txt:1028 (message):
  No SOURCES given to Zephyr library: rpmi
```

Only name the rpmi library as a built-artifact when CONFIG_RISCV_RPMI=y.