### PR TITLE
test: rpmi_srvgrp_base: ensure librpmi recovers from invalid service group

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,10 +18,12 @@ jobs:
   unit-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - shell: bash
+        timeout-minutes: 2
         run: |
           make -j check LIBRPMI_TEST=y

--- a/lib/rpmi_context.c
+++ b/lib/rpmi_context.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2024 Ventana Micro Systems Inc.
  */
 
+#include <stdio.h>
 #include <librpmi.h>
 
 #ifdef LIBRPMI_DEBUG
@@ -325,6 +326,11 @@ void rpmi_context_process_a2p_request(struct rpmi_context *cntx)
 	rmsg = cntx->req_msg;
 	amsg = cntx->ack_msg;
 	while (!rpmi_transport_dequeue(trans, RPMI_QUEUE_A2P_REQ, rmsg)) {
+		if (rmsg->header.servicegroup_id == 0)
+		{
+			printf("servicegroup_id: 0x%x\n", rmsg->header.servicegroup_id);
+		}
+
 		group = rpmi_context_find_group(cntx, rmsg->header.servicegroup_id);
 		if (!group) {
 			DPRINTF("%s: %s: service group ID 0x%x not found\n",

--- a/test/test_srvgrp_base.c
+++ b/test/test_srvgrp_base.c
@@ -70,7 +70,7 @@ static struct rpmi_test_scenario scenario_base_default = {
 	.init = test_scenario_default_init,
 	.cleanup = test_scenario_default_cleanup,
 
-	.num_tests = 7,
+	.num_tests = 8,
 	.tests = {
 		{
 			.name = "RPMI_BASE_SRV_ENABLE_NOTIFICATION",
@@ -123,7 +123,7 @@ static struct rpmi_test_scenario scenario_base_default = {
 				.service_id = RPMI_BASE_SRV_GET_PLATFORM_INFO,
 				.flags = RPMI_MSG_NORMAL_REQUEST,
 				.expected_data = &plat_info_val,
-				.expected_data_len = PLAT_INFO_LEN + sizeof(rpmi_uint32_t)*2,
+				.expected_data_len = PLAT_INFO_LEN + sizeof(rpmi_uint32_t) * 2,
 			},
 			.init_expected_data = test_init_expected_data_from_attrs,
 		},
@@ -151,6 +151,17 @@ static struct rpmi_test_scenario scenario_base_default = {
 				.expected_data_len = sizeof(attribs_expdata_default),
 			},
 			.init_expected_data = test_init_expected_data_from_attrs,
+		},
+		{
+			.name = "RPMI_INVALID_SRVGRP",
+			.attrs = {
+				.servicegroup_id = RPMI_SRVGRP_ID_MIN,
+				.service_id = (rpmi_uint8_t)42,
+				.flags = RPMI_MSG_NORMAL_REQUEST,
+				.expected_data = enable_notif_expdata_default,
+				.expected_data_len = sizeof(enable_notif_expdata_default),
+			},
+			.init_expected_data = NULL,
 		},
 	},
 };


### PR DESCRIPTION
Ensure that librpmi recovers from a message targeting an invalid service
    group.