### PR TITLE
librpmi: sync with upstream pr 72

### DIFF
--- a/lib/rpmi_service_group_performance.c
+++ b/lib/rpmi_service_group_performance.c
@@ -759,7 +759,7 @@ rpmi_service_group_perf_create(rpmi_uint32_t perf_count,
 
 	perfgrp->fc_memory_region = rpmi_env_zalloc(sizeof(struct rpmi_perf_fc_memory_region));
 	if (!perfgrp->fc_memory_region) {
-		DPRINTF("%s: failed to allocate perf service group instance\n",
+		DPRINTF("%s: failed to allocate perf fastchannel region\n",
 			__func__);
 		rpmi_env_free(perfgrp);
 		return NULL;

--- a/lib/rpmi_service_group_performance.c
+++ b/lib/rpmi_service_group_performance.c
@@ -761,6 +761,7 @@ rpmi_service_group_perf_create(rpmi_uint32_t perf_count,
 	if (!perfgrp->fc_memory_region) {
 		DPRINTF("%s: failed to allocate perf service group instance\n",
 			__func__);
+		rpmi_env_free(perfgrp);
 		return NULL;
 	}
 
@@ -770,6 +771,7 @@ rpmi_service_group_perf_create(rpmi_uint32_t perf_count,
 						 ops_priv);
 	if (!perfgrp->perf_tree) {
 		DPRINTF("%s: failed to initialize perf tree\n", __func__);
+		rpmi_env_free(perfgrp->fc_memory_region);
 		rpmi_env_free(perfgrp);
 		return NULL;
 	}

--- a/lib/rpmi_service_group_performance.c
+++ b/lib/rpmi_service_group_performance.c
@@ -814,6 +814,7 @@ void rpmi_service_group_perf_destroy(struct rpmi_service_group *group)
 		rpmi_env_free_lock(perfgrp->perf_tree[perfid].lock);
 
 	rpmi_env_free(perfgrp->perf_tree);
+	rpmi_env_free(perfgrp->fc_memory_region);
 	rpmi_env_free_lock(group->lock);
 	rpmi_env_free(group->priv);
 }


### PR DESCRIPTION
apply the following upstream commits from PR 72

* e8aea73bf1d73e7769a7b70dd4f3e3bb54ebdd66
* e029a3b69591fa689b4767060d9c0dea3b2a744c
* 387d8c1a506ccaa8a7fc5e86550fd61cd3a6f0f6
